### PR TITLE
fix slippages

### DIFF
--- a/playground/src/addLiquidity.ts
+++ b/playground/src/addLiquidity.ts
@@ -9,7 +9,6 @@ import {
   WMAS as _WMAS,
   USDC as _USDC,
   parseUnits,
-  Percent,
   ILBPair
 } from '@dusalabs/sdk'
 import { WalletClient } from '@massalabs/massa-web3'
@@ -57,11 +56,11 @@ export const addLiquidity = async () => {
   if (approveTxId1) await awaitFinalization(client, approveTxId1)
   if (approveTxId2) await awaitFinalization(client, approveTxId2)
 
-  // set amount slipage tolerance
-  const allowedAmountSlippage = 50 // in bips, 0.5% in this case
+  // set amount slippage tolerance
+  const allowedAmountSlippage = 50n // in bips, 0.5% in this case
 
   // set price slippage tolerance
-  const allowedPriceSlippage = 50 // in bips, 0.5% in this case
+  const allowedPriceSlippage = 50n // in bips, 0.5% in this case
 
   // set deadline for the transaction
   const currenTimeInMs = new Date().getTime()
@@ -77,8 +76,8 @@ export const addLiquidity = async () => {
     binStep,
     tokenAmountUSDC,
     tokenAmountWMAS,
-    new Percent(BigInt(allowedAmountSlippage)),
-    new Percent(BigInt(allowedPriceSlippage)),
+    allowedAmountSlippage,
+    allowedPriceSlippage,
     LiquidityDistribution.SPOT
   )
 

--- a/playground/src/removeLiquidity.ts
+++ b/playground/src/removeLiquidity.ts
@@ -6,7 +6,6 @@ import {
   WMAS as _WMAS,
   USDC as _USDC,
   ILBPair,
-  Percent
 } from '@dusalabs/sdk'
 import { WalletClient } from '@massalabs/massa-web3'
 import { awaitFinalization, createClient, logEvents } from './utils'
@@ -29,7 +28,7 @@ export const removeLiquidity = async () => {
   const router = LB_ROUTER_ADDRESS[CHAIN_ID]
 
   // set amount slipage tolerance
-  const allowedAmountSlippage = 50 // in bips, 0.5% in this case
+  const allowedAmountSlippage = 50n // in bips, 0.5% in this case
 
   // set deadline for the transaction
   const currenTimeInMs = new Date().getTime()
@@ -70,7 +69,7 @@ export const removeLiquidity = async () => {
     bins,
     totalSupplies,
     nonZeroAmounts.map(String),
-    new Percent(BigInt(allowedAmountSlippage))
+    allowedAmountSlippage
   )
 
   const params = pair.liquidityCallParameters({


### PR DESCRIPTION
I think there is a bug when computing slippage percentages:

If you want to set amountSlippage to 50 (0.5%)
```
 const amount0Min = new Fraction(1n)
      .add(amountSlippage)
      .invert()
      .multiply(amount0).quotient
```
Using the code above gives 1/51 that you multiply  by the amount..

Can you confirm there is an issue? im not 100% sure.
Here is a proposition to fix the issue. The change in `addLiquidityParameters` and `calculateAmountsToRemove` signature are intentionnaly breaking to avoid mixing versions..