### PR TITLE
fix call SC gas estimation

### DIFF
--- a/src/contracts/base.ts
+++ b/src/contracts/base.ts
@@ -78,7 +78,9 @@ export class IBaseContract {
   public async estimateGas(params: BaseCallData) {
     return this.simulate(params)
       .then((r) =>
-        BigInt(Math.min(r.info.gas_cost * 1.1, Number(MAX_GAS_CALL)))
+        BigInt(
+          Math.floor(Math.min(r.info.gas_cost * 1.1, Number(MAX_GAS_CALL)))
+        )
       ) // 10% extra gas for safety
       .catch(() => MAX_GAS_CALL)
   }


### PR DESCRIPTION
I noticed the gas estimation fails with the following error. 

```
RangeError: The number 10956502.700000001 cannot be converted to a BigInt because it is not an integer
    at BigInt (<anonymous>)
    at <anonymous> (/home/pseznec/dev/massa-asc/node_modules/@dusalabs/sdk/src/contracts/base.ts:84:4)
```

MAX_GAS_CALL is set in catch, hiding the issue.

Adding a Math.floor should do the job